### PR TITLE
feat(bazar): R2 custom upload — página admin + descarga en /bazar

### DIFF
--- a/composables/useR2Upload.ts
+++ b/composables/useR2Upload.ts
@@ -1,0 +1,45 @@
+import { ref } from 'vue';
+import api from '~/utils/api';
+
+export function useR2Upload() {
+    const progress = ref(0);
+    const error = ref<string | null>(null);
+
+    async function upload(file: File, kind: 'image' | 'file'): Promise<{ key: string; token: string }> {
+        error.value = null;
+        progress.value = 0;
+
+        const { data } = await api.post('/products/upload-url', {
+            kind,
+            contentType: file.type || (kind === 'file' ? 'application/octet-stream' : 'image/jpeg'),
+            size: file.size,
+        });
+
+        const { uploadUrl, key, uploadToken } = data as {
+            uploadUrl: string; key: string; uploadToken: string;
+        };
+
+        // XHR nos da progreso; fetch() no.
+        await new Promise<void>((resolve, reject) => {
+            const xhr = new XMLHttpRequest();
+            xhr.open('PUT', uploadUrl);
+            xhr.setRequestHeader('Content-Type', file.type || 'application/octet-stream');
+            xhr.upload.onprogress = (e) => {
+                if (e.lengthComputable) progress.value = Math.round((e.loaded / e.total) * 100);
+            };
+            xhr.onload = () => {
+                if (xhr.status >= 200 && xhr.status < 300) resolve();
+                else reject(new Error(`R2 upload falló: ${xhr.status}`));
+            };
+            xhr.onerror = () => reject(new Error('Error de red al subir a R2'));
+            xhr.send(file);
+        }).catch((e: Error) => {
+            error.value = e.message;
+            throw e;
+        });
+
+        return { key, token: uploadToken };
+    }
+
+    return { upload, progress, error };
+}

--- a/n8n/docker-compose.yml
+++ b/n8n/docker-compose.yml
@@ -1,0 +1,33 @@
+## Copia este archivo al Pi como /home/shongyi/n8n/docker-compose.yml
+## Crea /home/shongyi/n8n/.env con:
+##   N8N_HOST=n8n.shongyi.com          # o el subdominio que uses
+##   N8N_BASIC_AUTH_USER=<usuario>
+##   N8N_BASIC_AUTH_PASSWORD=<password fuerte>
+##   TASKMAN_API_URL=http://host.docker.internal:3000   # backend en la misma Pi
+##   SYNC_SECRET=<mismo valor que el .env del backend>
+## Luego: docker compose up -d
+## Cloudflare Tunnel: apunta N8N_HOST → http://localhost:5678 (mismo túnel del backend, hostname distinto)
+
+services:
+  n8n:
+    image: n8nio/n8n:latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:5678:5678"   # solo accesible localmente; Cloudflare Tunnel lo expone
+    environment:
+      - N8N_HOST=${N8N_HOST}
+      - N8N_PORT=5678
+      - N8N_PROTOCOL=https
+      - WEBHOOK_URL=https://${N8N_HOST}/
+      - N8N_BASIC_AUTH_ACTIVE=true
+      - N8N_BASIC_AUTH_USER=${N8N_BASIC_AUTH_USER}
+      - N8N_BASIC_AUTH_PASSWORD=${N8N_BASIC_AUTH_PASSWORD}
+      - GENERIC_TIMEZONE=America/Mexico_City
+      - TZ=America/Mexico_City
+      # variables leídas desde los workflows con {{ $env.NOMBRE }}
+      - TASKMAN_API_URL=${TASKMAN_API_URL}
+      - SYNC_SECRET=${SYNC_SECRET}
+    volumes:
+      - ./data:/home/node/.n8n
+    extra_hosts:
+      - "host.docker.internal:host-gateway"   # para llamar al backend en el mismo Pi

--- a/pages/bazar.vue
+++ b/pages/bazar.vue
@@ -20,7 +20,11 @@
       </div>
 
       <!-- Galería de Productos -->
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+      <div v-if="error" class="text-center text-destructive py-8">{{ error }}</div>
+      <div v-else-if="products.length === 0" class="text-center text-muted-foreground py-8">
+        No hay productos disponibles todavía.
+      </div>
+      <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
 
         <div v-for="product in products" :key="product.id" class="group flex flex-col bg-card rounded-2xl overflow-hidden border border-border/60 hover:shadow-2xl hover:shadow-primary/5 transition-all duration-300">
           <div class="aspect-square bg-secondary/50 overflow-hidden relative">
@@ -39,17 +43,26 @@
               <div class="flex items-center justify-between">
                 <span class="font-sans font-medium text-foreground">{{ product.price }}</span>
               </div>
-              <a
-                v-if="product.fileUrl"
-                :href="`${apiBase}/products/${product.id}/download`"
-                class="inline-flex items-center gap-1 text-xs text-primary hover:underline"
-                target="_blank"
-              >
-                Descargar
-                <span v-if="product.fileSizeBytes" class="text-muted-foreground">
-                  ({{ formatSize(product.fileSizeBytes) }})
-                </span>
-              </a>
+              <div class="flex items-center justify-between">
+                <a
+                  v-if="product.fileUrl"
+                  :href="`${apiBase}/products/${product.id}/download`"
+                  class="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+                  target="_blank"
+                >
+                  Descargar
+                  <span v-if="product.fileSizeBytes" class="text-muted-foreground">
+                    ({{ formatSize(product.fileSizeBytes) }})
+                  </span>
+                </a>
+                <button
+                  type="button"
+                  class="rounded-md p-2 hover:bg-accent"
+                  aria-label="Agregar al carrito"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/><path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"/></svg>
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -61,8 +74,23 @@
 </template>
 
 <script setup lang="ts">
+interface Product {
+  id: number;
+  title: string;
+  description: string;
+  price: number | string;
+  origin?: string;
+  fileUrl?: string | null;
+  fileSizeBytes?: number | null;
+  source?: string;
+  licenseType?: string;
+  licenseAttribution?: string;
+  imageUrl?: string;
+}
+
 const apiBase = import.meta.env.VITE_API_URL || 'https://taskapi.shongyi.com/api';
-const products = ref<any[]>([]);
+const products = ref<Product[]>([]);
+const error = ref<string | null>(null);
 
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -105,11 +133,11 @@ const categorias = [
 onMounted(async () => {
   try {
     const response = await fetch(`${apiBase}/products`);
-    if (response.ok) {
-      products.value = await response.json();
-    }
-  } catch (error) {
-    console.error('Error fetching products:', error);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    products.value = await response.json();
+  } catch (e: any) {
+    error.value = 'No se pudieron cargar los productos. Intenta recargar la página.';
+    console.error('Error fetching products:', e);
   }
 });
 </script>

--- a/pages/bazar.vue
+++ b/pages/bazar.vue
@@ -21,70 +21,35 @@
 
       <!-- Galería de Productos -->
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
-        
-        <!-- Producto Ejemplo 1 -->
-        <div class="group flex flex-col bg-card rounded-2xl overflow-hidden border border-border/60 hover:shadow-2xl hover:shadow-primary/5 transition-all duration-300">
+
+        <div v-for="product in products" :key="product.id" class="group flex flex-col bg-card rounded-2xl overflow-hidden border border-border/60 hover:shadow-2xl hover:shadow-primary/5 transition-all duration-300">
           <div class="aspect-square bg-secondary/50 overflow-hidden relative">
             <div class="absolute inset-0 flex items-center justify-center text-muted-foreground/30 font-serif italic">
               [ Imagen del Producto ]
             </div>
             <!-- Etiqueta de Origen -->
             <div class="absolute top-4 left-4 bg-background/80 backdrop-blur-sm px-3 py-1 text-xs font-semibold rounded-full border border-border/50 text-foreground">
-              Crafted in 3D
+              {{ product.origin || 'Crafted' }}
             </div>
           </div>
           <div class="p-6 flex flex-col flex-grow">
-            <h3 class="font-serif text-xl font-semibold mb-2 group-hover:text-primary transition-colors">Soporte Geométrico para Auriculares</h3>
-            <p class="text-muted-foreground text-sm mb-4 line-clamp-2">Un diseño minimalista y robusto para mantener tu espacio de trabajo ordenado.</p>
-            <div class="mt-auto flex items-center justify-between">
-              <span class="font-sans font-medium text-foreground">$450 MXN</span>
-              <button class="text-primary hover:text-primary/80 transition-colors">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="21" r="1"/><circle cx="19" cy="21" r="1"/><path d="M2.05 2.05h2l2.66 12.42a2 2 0 0 0 2 1.58h9.78a2 2 0 0 0 1.95-1.57l1.65-7.43H5.12"/></svg>
-              </button>
-            </div>
-          </div>
-        </div>
-
-        <!-- Producto Ejemplo 2 (Lifestyle/Cuero sugerido) -->
-        <div class="group flex flex-col bg-card rounded-2xl overflow-hidden border border-border/60 hover:shadow-2xl hover:shadow-primary/5 transition-all duration-300">
-          <div class="aspect-square bg-secondary/50 overflow-hidden relative">
-            <div class="absolute inset-0 flex items-center justify-center text-muted-foreground/30 font-serif italic">
-              [ Imagen del Producto ]
-            </div>
-            <div class="absolute top-4 left-4 bg-background/80 backdrop-blur-sm px-3 py-1 text-xs font-semibold rounded-full border border-border/50 text-foreground">
-              Handcrafted
-            </div>
-          </div>
-          <div class="p-6 flex flex-col flex-grow">
-            <h3 class="font-serif text-xl font-semibold mb-2 group-hover:text-primary transition-colors">Billetera de Ruta</h3>
-            <p class="text-muted-foreground text-sm mb-4 line-clamp-2">Pieza rústica y pulida, diseñada para la durabilidad. Descubre el arte detrás de los detalles.</p>
-            <div class="mt-auto flex items-center justify-between">
-              <span class="font-sans font-medium text-foreground">$850 MXN</span>
-              <button class="text-primary hover:text-primary/80 transition-colors">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="21" r="1"/><circle cx="19" cy="21" r="1"/><path d="M2.05 2.05h2l2.66 12.42a2 2 0 0 0 2 1.58h9.78a2 2 0 0 0 1.95-1.57l1.65-7.43H5.12"/></svg>
-              </button>
-            </div>
-          </div>
-        </div>
-
-        <!-- Producto Ejemplo 3 -->
-        <div class="group flex flex-col bg-card rounded-2xl overflow-hidden border border-border/60 hover:shadow-2xl hover:shadow-primary/5 transition-all duration-300">
-          <div class="aspect-square bg-secondary/50 overflow-hidden relative">
-            <div class="absolute inset-0 flex items-center justify-center text-muted-foreground/30 font-serif italic">
-              [ Imagen del Producto ]
-            </div>
-            <div class="absolute top-4 left-4 bg-background/80 backdrop-blur-sm px-3 py-1 text-xs font-semibold rounded-full border border-border/50 text-foreground">
-              Tech
-            </div>
-          </div>
-          <div class="p-6 flex flex-col flex-grow">
-            <h3 class="font-serif text-xl font-semibold mb-2 group-hover:text-primary transition-colors">Módulo de Control ESP32</h3>
-            <p class="text-muted-foreground text-sm mb-4 line-clamp-2">El cerebro perfecto para tu próximo proyecto de automatización en casa o en el taller.</p>
-            <div class="mt-auto flex items-center justify-between">
-              <span class="font-sans font-medium text-foreground">$220 MXN</span>
-              <button class="text-primary hover:text-primary/80 transition-colors">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="21" r="1"/><circle cx="19" cy="21" r="1"/><path d="M2.05 2.05h2l2.66 12.42a2 2 0 0 0 2 1.58h9.78a2 2 0 0 0 1.95-1.57l1.65-7.43H5.12"/></svg>
-              </button>
+            <h3 class="font-serif text-xl font-semibold mb-2 group-hover:text-primary transition-colors">{{ product.title }}</h3>
+            <p class="text-muted-foreground text-sm mb-4 line-clamp-2">{{ product.description }}</p>
+            <div class="mt-auto space-y-3">
+              <div class="flex items-center justify-between">
+                <span class="font-sans font-medium text-foreground">{{ product.price }}</span>
+              </div>
+              <a
+                v-if="product.fileUrl"
+                :href="`${apiBase}/products/${product.id}/download`"
+                class="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+                target="_blank"
+              >
+                Descargar
+                <span v-if="product.fileSizeBytes" class="text-muted-foreground">
+                  ({{ formatSize(product.fileSizeBytes) }})
+                </span>
+              </a>
             </div>
           </div>
         </div>
@@ -95,7 +60,16 @@
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
+const apiBase = import.meta.env.VITE_API_URL || 'https://taskapi.shongyi.com/api';
+const products = ref<any[]>([]);
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 useSeoMeta({
   title: 'El Bazar — Productos en impresión 3D y accesorios',
   description: 'Galería de creaciones físicas: piezas en impresión 3D, accesorios de estilo de vida y electrónica diseñada con detalle.',
@@ -126,4 +100,16 @@ const categorias = [
   'Estilo de Vida y Equipamiento',
   'Electrónica'
 ];
+
+// Fetch products from API
+onMounted(async () => {
+  try {
+    const response = await fetch(`${apiBase}/products`);
+    if (response.ok) {
+      products.value = await response.json();
+    }
+  } catch (error) {
+    console.error('Error fetching products:', error);
+  }
+});
 </script>

--- a/pages/taskman/admin/bazar/upload.vue
+++ b/pages/taskman/admin/bazar/upload.vue
@@ -1,0 +1,160 @@
+<template>
+  <div class="max-w-2xl mx-auto space-y-6">
+    <div>
+      <h1 class="text-3xl font-serif font-bold">Subir modelo al Bazar</h1>
+      <p class="text-muted-foreground">Diseños propios. Imagen + STL/3MF van directo al almacenamiento en la nube.</p>
+    </div>
+
+    <form @submit.prevent="submit" class="space-y-4">
+      <div class="space-y-2">
+        <label class="text-sm font-medium">Título</label>
+        <input v-model="title" required class="w-full rounded-md border bg-background px-3 py-2" />
+      </div>
+
+      <div class="space-y-2">
+        <label class="text-sm font-medium">Descripción</label>
+        <textarea v-model="description" required rows="4" class="w-full rounded-md border bg-background px-3 py-2" />
+      </div>
+
+      <div class="grid grid-cols-2 gap-4">
+        <div class="space-y-2">
+          <label class="text-sm font-medium">Precio MXN</label>
+          <input v-model.number="price" type="number" min="0" step="1" class="w-full rounded-md border bg-background px-3 py-2" />
+        </div>
+        <div class="space-y-2">
+          <label class="text-sm font-medium">Categoría</label>
+          <select v-model="category" class="w-full rounded-md border bg-background px-3 py-2">
+            <option value="Impresión 3D">Impresión 3D</option>
+            <option value="Estilo de Vida y Equipamiento">Estilo de Vida y Equipamiento</option>
+            <option value="Electrónica">Electrónica</option>
+            <option value="Otros">Otros</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="space-y-2">
+        <label class="text-sm font-medium">Imagen (jpg/png/webp)</label>
+        <input type="file" accept="image/*" @change="onImageChange" required class="block w-full text-sm" />
+        <div v-if="image.progress > 0" class="text-xs text-muted-foreground">
+          Imagen: {{ image.progress }}%
+        </div>
+      </div>
+
+      <div class="space-y-2">
+        <label class="text-sm font-medium">Archivo (STL/3MF)</label>
+        <input type="file" accept=".stl,.3mf,.STL,.3MF" @change="onFileChange" required class="block w-full text-sm" />
+        <div v-if="file.progress > 0" class="text-xs text-muted-foreground">
+          Archivo: {{ file.progress }}%
+        </div>
+      </div>
+
+      <p v-if="errorMsg" class="text-sm text-destructive">{{ errorMsg }}</p>
+
+      <button type="submit" :disabled="!canSubmit || submitting"
+              class="w-full rounded-md bg-primary text-primary-foreground py-2 disabled:opacity-50">
+        {{ submitting ? 'Publicando…' : 'Publicar en el Bazar' }}
+      </button>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive, computed } from 'vue';
+import { useRouter } from 'vue-router';
+import { useAuthStore } from '~/stores/auth';
+import api from '~/utils/api';
+import { useR2Upload } from '~/composables/useR2Upload';
+
+definePageMeta({ layout: 'taskman' });
+
+const authStore = useAuthStore();
+const router = useRouter();
+
+// Guard client-side (defensa en profundidad; backend igual valida)
+onMounted(() => {
+  // ponytail: guard sólo por email; migrar a role cuando aparezca segundo admin.
+  if (!authStore.user?.email) {
+    router.replace('/login');
+  }
+});
+
+const title = ref('');
+const description = ref('');
+const price = ref(0);
+const category = ref('Impresión 3D');
+
+const image = reactive({
+  file: null as File | null,
+  key: '' as string,
+  token: '' as string,
+  progress: 0,
+});
+const file = reactive({
+  file: null as File | null,
+  key: '' as string,
+  token: '' as string,
+  progress: 0,
+});
+
+const errorMsg = ref('');
+const submitting = ref(false);
+
+async function onImageChange(e: Event) {
+  const f = (e.target as HTMLInputElement).files?.[0];
+  if (!f) return;
+  image.file = f;
+  errorMsg.value = '';
+  try {
+    const uploader = useR2Upload();
+    const res = await uploader.upload(f, 'image');
+    image.key = res.key;
+    image.token = res.token;
+    image.progress = 100;
+  } catch (e: any) {
+    errorMsg.value = `Imagen: ${e.message || e}`;
+  }
+}
+
+async function onFileChange(e: Event) {
+  const f = (e.target as HTMLInputElement).files?.[0];
+  if (!f) return;
+  file.file = f;
+  errorMsg.value = '';
+  try {
+    const uploader = useR2Upload();
+    const res = await uploader.upload(f, 'file');
+    file.key = res.key;
+    file.token = res.token;
+    file.progress = 100;
+  } catch (e: any) {
+    errorMsg.value = `Archivo: ${e.message || e}`;
+  }
+}
+
+const canSubmit = computed(() =>
+  title.value && description.value && image.key && file.key
+);
+
+async function submit() {
+  if (!canSubmit.value) return;
+  submitting.value = true;
+  errorMsg.value = '';
+  try {
+    const { data } = await api.post('/products/custom', {
+      title: title.value,
+      description: description.value,
+      price: price.value,
+      category: category.value,
+      imageKey: image.key,
+      imageToken: image.token,
+      fileKey: file.key,
+      fileToken: file.token,
+    });
+    router.push(`/bazar?highlight=${data.product.id}`);
+  } catch (e: any) {
+    errorMsg.value = e.response?.data?.error || e.message || 'Error al publicar';
+  } finally {
+    submitting.value = false;
+  }
+}
+</script>

--- a/pages/taskman/admin/bazar/upload.vue
+++ b/pages/taskman/admin/bazar/upload.vue
@@ -59,7 +59,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, computed } from 'vue';
+import { ref, reactive, computed, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { useAuthStore } from '~/stores/auth';
 import api from '~/utils/api';
@@ -104,14 +104,17 @@ async function onImageChange(e: Event) {
   if (!f) return;
   image.file = f;
   errorMsg.value = '';
+  const uploader = useR2Upload();
+  const stop = watch(() => uploader.progress.value, (v) => { image.progress = v; });
   try {
-    const uploader = useR2Upload();
     const res = await uploader.upload(f, 'image');
     image.key = res.key;
     image.token = res.token;
     image.progress = 100;
   } catch (e: any) {
     errorMsg.value = `Imagen: ${e.message || e}`;
+  } finally {
+    stop();
   }
 }
 
@@ -120,14 +123,17 @@ async function onFileChange(e: Event) {
   if (!f) return;
   file.file = f;
   errorMsg.value = '';
+  const uploader = useR2Upload();
+  const stop = watch(() => uploader.progress.value, (v) => { file.progress = v; });
   try {
-    const uploader = useR2Upload();
     const res = await uploader.upload(f, 'file');
     file.key = res.key;
     file.token = res.token;
     file.progress = 100;
   } catch (e: any) {
     errorMsg.value = `Archivo: ${e.message || e}`;
+  } finally {
+    stop();
   }
 }
 


### PR DESCRIPTION
  ## Summary
  - Composable `useR2Upload()` + página `/taskman/admin/bazar/upload` para subir imagen + STL/3MF directo del navegador a Cloudflare R2 vía URL firmada.
  - `pages/bazar.vue` cableado a `GET /api/products` con botón "Descargar" apuntando a `/api/products/:id/download` y tamaño formateado.
  - Elimina el workflow n8n `custom-upload.json`.

  ## Test plan
  - [x] `npm run build` exit 0
  - [ ] Deploy Cloudflare Pages exitoso
  - [ ] `/taskman/admin/bazar/upload` carga con JWT admin
  - [ ] Botón "Descargar" aparece en cards con `fileUrl`